### PR TITLE
Add DigiByte support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [25.07.4/2.5.4] 2025-07-21
+### added
+- add support for DigiByte (dgb)
+
 ## [25.07.3/2.5.3] 2025-07-08
 ### added
 - add optional environment to slack logging handler

--- a/src/graphsenselib/config/config.py
+++ b/src/graphsenselib/config/config.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, field_validator
 
 from ..utils import first_or_default, flatten
 
-supported_base_currencies = ["btc", "eth", "ltc", "bch", "zec", "trx"]
+supported_base_currencies = ["btc", "eth", "ltc", "bch", "zec", "trx", "dgb"]
 default_environments = ["prod", "test", "dev", "exp1", "exp2", "exp3"]
 schema_types = ["utxo", "account", "account_trx"]
 keyspace_types = ["raw", "transformed"]
@@ -25,6 +25,7 @@ avg_blocktimes_by_currencies = {
     "bch": 600,
     "zec": 75,
     "ltc": 150,
+    "dgb": 15,
 }
 
 reorg_backoff_blocks = {
@@ -34,6 +35,7 @@ reorg_backoff_blocks = {
     "bch": 15,
     "zec": 150,
     "ltc": 12,
+    "dgb": 120,
 }
 
 

--- a/src/graphsenselib/ingest/delta/sink.py
+++ b/src/graphsenselib/ingest/delta/sink.py
@@ -454,6 +454,7 @@ CONFIG_MAP = {
     "ltc": UTXO_DBWRITE_CONFIG,
     "bch": UTXO_DBWRITE_CONFIG,
     "zec": UTXO_DBWRITE_CONFIG,
+    "dgb": UTXO_DBWRITE_CONFIG,
 }
 
 

--- a/src/graphsenselib/ingest/dump.py
+++ b/src/graphsenselib/ingest/dump.py
@@ -17,7 +17,7 @@ from graphsenselib.utils import first_or_default
 
 from ..config import get_reorg_backoff_blocks
 
-SUPPORTED = ["trx", "eth", "btc", "ltc", "bch", "zec"]
+SUPPORTED = ["trx", "eth", "btc", "ltc", "bch", "zec", "dgb"]
 
 # filesizes should be between 100 and 1000 MB and partitions > 1000MB
 # therefore we try to write files that are between 100 and 1000 MB and
@@ -30,6 +30,7 @@ FILESIZES = {
     "eth": 1000,
     "btc": 1000,
     "bch": 1000,
+    "dgb": 1000,
 }
 
 PARTITIONSIZES = {
@@ -39,6 +40,7 @@ PARTITIONSIZES = {
     "eth": 10000,
     "btc": 10000,
     "bch": 10000,
+    "dgb": 10000,
 }
 
 
@@ -92,7 +94,7 @@ def export_delta(
         source = SourceETH(provider_uri=provider_uri, provider_timeout=provider_timeout)
         transformer = TransformerETH(partition_batch_size, "eth")
 
-    elif currency in ["btc", "ltc", "bch", "zec"]:
+    elif currency in ["btc", "ltc", "bch", "zec", "dgb"]:
         source = SourceUTXO(
             provider_uri=provider_uri,
             network=currency,

--- a/src/graphsenselib/ingest/ingestrunner.py
+++ b/src/graphsenselib/ingest/ingestrunner.py
@@ -15,6 +15,7 @@ AVG_BLOCKTIME = {
     "zec": int(1.25 * 60),
     "btc": 10 * 60,
     "bch": 10 * 60,
+    "dgb": 15,
 }
 
 

--- a/src/graphsenselib/ingest/utxo.py
+++ b/src/graphsenselib/ingest/utxo.py
@@ -27,6 +27,7 @@ try:
         # is not filled correctly.
         "bch": Chain.BITCOIN,
         "zec": Chain.ZCASH,
+        "dgb": Chain.BITCOIN,
     }
 
 

--- a/src/graphsenselib/utils/address.py
+++ b/src/graphsenselib/utils/address.py
@@ -272,6 +272,9 @@ converters = {
     "zec": AddressConverterBtcLike(
         bech32_prefix=None, nonstandard_prefix="nonstandard"
     ),
+    "dgb": AddressConverterBtcLike(
+        bech32_prefix="dgb1", nonstandard_prefix="nonstandard"
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- add `dgb` to supported currencies and configure block time and reorg backoff
- extend ingest modules for DigiByte
- add DigiByte address converter
- document DigiByte support in changelog

## Testing
- `ruff check .`
- `pytest -v -m "not slow"` *(fails: ModuleNotFoundError: No module named 'goodconf')*

------
https://chatgpt.com/codex/tasks/task_b_687d860ec2c4832b9de1244fcf63cdce